### PR TITLE
Increase o3 model timeout from 10 to 30 minutes

### DIFF
--- a/mcp_second_brain/tools/definitions.py
+++ b/mcp_second_brain/tools/definitions.py
@@ -60,7 +60,7 @@ class ChatWithO3(ToolSpec):
     model_name = "o3"
     adapter_class = "openai"
     context_window = 200_000
-    timeout = 600
+    timeout = 1800
     
     # Custom prompt template for o3 reasoning models
     prompt_template = """## Task Instructions


### PR DESCRIPTION
## Summary
- Increased o3 model timeout from 600 seconds (10 minutes) to 1800 seconds (30 minutes)
- This prevents timeouts when o3 is processing complex analysis tasks

## Test plan
- [x] Updated timeout value in `mcp_second_brain/tools/definitions.py`
- [x] Test with complex analysis tasks to verify 30-minute timeout is sufficient
- [x] Verify o3-pro still uses its 45-minute timeout

🤖 Generated with [Claude Code](https://claude.ai/code)