### PR TITLE
Implement automatic log redaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ CONTEXT_PERCENTAGE=0.85
 DEFAULT_TEMPERATURE=0.2
 ```
 
+### Logging and Secret Redaction
+The server installs a `SecretRedactionFilter` that automatically replaces any
+`sk-` style keys and values of environment variables ending with `_KEY` or
+`_SECRET` with `[REDACTED]` before they are written to the log files.
+
 ### Google Cloud Authentication
 
 The server requires Google Cloud authentication for Gemini models. See [docs/authentication-guide.md](docs/authentication-guide.md) for detailed setup instructions.
@@ -464,4 +469,4 @@ pytest tests/integration_mcp -v         # MCP integration tests
 
 ## 📄 License
 
-Private repository - see license terms.
+Private repository - see license terms

--- a/SECURITY_TODO.md
+++ b/SECURITY_TODO.md
@@ -22,6 +22,7 @@ Tests for these features are marked with `@pytest.mark.xfail` to document the ga
 - Detects patterns like `sk-[alphanumeric]` (OpenAI keys)
 - Redacts environment variable values ending in `_KEY` or `_SECRET`
 - Replaces with `[REDACTED]` or similar
+**Status**: Implemented as `SecretRedactionFilter` in `mcp_second_brain.utils.log_filter`
 
 ## Priority 2 - Important Enhancements
 
@@ -42,5 +43,5 @@ Before deploying to production or making the server publicly accessible:
 ## Tracking
 
 - [ ] Path traversal protection
-- [ ] Automatic log redaction
+- [x] Automatic log redaction
 - [ ] Gitignore negation support

--- a/mcp_second_brain/server.py
+++ b/mcp_second_brain/server.py
@@ -6,6 +6,7 @@ import logging
 import os
 from logging.handlers import QueueHandler, QueueListener
 import queue
+from .utils.log_filter import SecretRedactionFilter
 
 # Import all tool definitions to register them
 from .tools import definitions  # noqa: F401 # This import triggers the @tool decorators
@@ -32,6 +33,8 @@ queue_listener = QueueListener(log_queue, file_handler, console_handler)
 queue_listener.start()
 
 logging.basicConfig(level=logging.INFO, handlers=[queue_handler])
+root_logger = logging.getLogger()
+root_logger.addFilter(SecretRedactionFilter())
 logger = logging.getLogger(__name__)
 
 # Initialize FastMCP server

--- a/mcp_second_brain/utils/log_filter.py
+++ b/mcp_second_brain/utils/log_filter.py
@@ -1,0 +1,22 @@
+import logging
+import os
+import re
+
+class SecretRedactionFilter(logging.Filter):
+    """Filter that redacts secrets from log records."""
+
+    SECRET_PATTERN = re.compile(r"sk-[A-Za-z0-9]+")
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        try:
+            message = record.getMessage()
+        except Exception:
+            return True
+        redacted = self.SECRET_PATTERN.sub("[REDACTED]", message)
+        for name, value in os.environ.items():
+            if (name.upper().endswith("_KEY") or name.upper().endswith("_SECRET")) and value:
+                redacted = redacted.replace(value, "[REDACTED]")
+        if redacted != message:
+            record.msg = redacted
+            record.args = ()
+        return True

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -5,6 +5,7 @@ import logging
 import os
 import pytest
 from mcp_second_brain.config import Settings
+from mcp_second_brain.utils.log_filter import SecretRedactionFilter
 
 
 class TestLoggingSecurity:
@@ -52,7 +53,6 @@ class TestLoggingSecurity:
         assert "sk-1234567890abcdef" not in caplog.text
         assert "***" in caplog.text
     
-    @pytest.mark.xfail(reason="Logging sanitization not yet implemented")
     def test_automatic_secret_redaction(self, caplog, monkeypatch):
         """Test that secrets are automatically redacted from logs."""
         # This test documents a feature we should implement
@@ -62,6 +62,7 @@ class TestLoggingSecurity:
         
         monkeypatch.setenv("OPENAI_API_KEY", "sk-supersecret123")
         caplog.set_level(logging.DEBUG)
+        logging.getLogger().addFilter(SecretRedactionFilter())
         
         logger = logging.getLogger("mcp_second_brain")
         # Even if someone accidentally logs the key
@@ -69,4 +70,4 @@ class TestLoggingSecurity:
         
         # It should be automatically redacted
         assert "sk-supersecret123" not in caplog.text
-        assert "sk-***" in caplog.text or "[REDACTED]" in caplog.text
+        assert "Using key: [REDACTED]" in caplog.text


### PR DESCRIPTION
## Summary
- add `SecretRedactionFilter` to scrub secrets from logs
- register the filter in `server.py`
- test redaction behaviour
- document the filter in `README` and `SECURITY_TODO`

## Testing
- `pre-commit run --files mcp_second_brain/utils/log_filter.py mcp_second_brain/server.py tests/unit/test_logging.py SECURITY_TODO.md README.md` *(fails: pre-commit not found)*
- `pytest -q tests/unit/test_logging.py::TestLoggingSecurity::test_automatic_secret_redaction` *(fails: ModuleNotFoundError: pytest_asyncio)*

------
https://chatgpt.com/codex/tasks/task_e_685e8b5badd083318bed66e349f21b3d