### PR TITLE
Refactor attachment search to use explicit IDs

### DIFF
--- a/GITHUB_ISSUES_TODO.md
+++ b/GITHUB_ISSUES_TODO.md
@@ -91,6 +91,10 @@ Global `current_attachment_stores` can bleed between parallel calls, causing rac
 - Add tests for concurrent execution
 - Consider alternative approaches if ContextVars prove problematic
 
+### Status
+Resolved by passing attachment vector store IDs explicitly and ensuring
+each execution uses its own list.
+
 ---
 
 ## 6. Refactor Monolithic OpenAIAdapter

--- a/mcp_second_brain/tools/executor.py
+++ b/mcp_second_brain/tools/executor.py
@@ -14,7 +14,6 @@ from .parameter_router import ParameterRouter
 # Project memory imports
 from ..memory import store_conversation_memory
 from ..config import get_settings
-from .search_attachments import current_attachment_stores
 
 logger = logging.getLogger(__name__)
 
@@ -78,10 +77,6 @@ class ToolExecutor:
                 if files:
                     vs_id = await self.vector_store_manager.create(files)
                     vector_store_ids = [vs_id] if vs_id else None
-
-                    # Set context variable for attachment search
-                    if vector_store_ids:
-                        current_attachment_stores.set(vector_store_ids)
 
             # Memory stores are no longer auto-attached
             # Models should use search_project_memory function to access memory
@@ -175,8 +170,6 @@ class ToolExecutor:
             if vs_id:
                 await vector_store_manager.delete(vs_id)
 
-            # Clear attachment context
-            current_attachment_stores.set([])
 
             # Wait for memory tasks to complete
             if memory_tasks:

--- a/tests/internal/test_attachment_concurrency.py
+++ b/tests/internal/test_attachment_concurrency.py
@@ -1,0 +1,36 @@
+import asyncio
+from unittest.mock import patch
+
+import pytest
+
+from mcp_second_brain.tools.search_attachments import SearchAttachmentAdapter
+
+
+@pytest.mark.asyncio
+async def test_concurrent_attachment_search_isolation():
+    """Ensure attachment IDs do not bleed between concurrent searches."""
+
+    async def fake_search(self, query: str, store_id: str, max_results: int):
+        await asyncio.sleep(0.01)
+        return [{"content": f"{store_id} result", "store_id": store_id, "score": 1.0}]
+
+    with patch.object(SearchAttachmentAdapter, "_search_single_store", fake_search):
+        adapter1 = SearchAttachmentAdapter()
+        adapter2 = SearchAttachmentAdapter()
+
+        async def run1():
+            return await adapter1.generate(
+                prompt="", query="alpha", vector_store_ids=["vs_A"], max_results=1
+            )
+
+        async def run2():
+            return await adapter2.generate(
+                prompt="", query="beta", vector_store_ids=["vs_B"], max_results=1
+            )
+
+        res1, res2 = await asyncio.gather(run1(), run2())
+
+        assert "vs_A" in res1
+        assert "vs_B" in res2
+        assert "vs_B" not in res1
+        assert "vs_A" not in res2


### PR DESCRIPTION
## Summary
- pass attachment vector store IDs directly to `SearchAttachmentAdapter`
- remove `current_attachment_stores` ContextVar and cleanup logic
- adjust `ToolExecutor` to drop contextvar usage
- update end-to-end attachment search tests
- add new concurrency test for attachment search
- mark race condition issue as resolved in docs

## Testing
- `python -m py_compile mcp_second_brain/tools/search_attachments.py mcp_second_brain/tools/executor.py tests/internal/test_attachment_concurrency.py`
- `pytest tests/internal/test_attachment_concurrency.py -q` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_685e8cae6d38833190d826142d1bbbf3