### PR TITLE
Add pytest-asyncio to dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "pydantic-settings>=2.0.0",
     "python-dotenv>=1.0.0",
     "pyyaml>=6.0.0",
+    "pytest-asyncio>=0.21",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- include `pytest-asyncio` in main install requirements

## Testing
- `pre-commit run --files pyproject.toml` *(fails: command not found)*
- `pytest tests/unit -q -m "not slow and not e2e and not integration" --tb=short` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_685e8eaf38b083319855db5bef3fcbce