### PR TITLE
Fix tests for mandatory session

### DIFF
--- a/mcp_second_brain/gemini_session_cache.py
+++ b/mcp_second_brain/gemini_session_cache.py
@@ -7,6 +7,8 @@ import logging
 from typing import List, Dict
 
 from mcp_second_brain.config import get_settings
+import os
+import tempfile
 
 logger = logging.getLogger(__name__)
 
@@ -20,6 +22,10 @@ class _SQLiteGeminiSessionCache:
     """SQLite-backed store for Gemini conversation history."""
 
     def __init__(self, db_path: str = _DB_PATH, ttl: int = _DEFAULT_TTL):
+        if os.getenv("MCP_ADAPTER_MOCK") == "1" and db_path == _DB_PATH:
+            tmp = tempfile.NamedTemporaryFile(suffix=".sqlite3", delete=False)
+            db_path = tmp.name
+            tmp.close()
         self.db_path = db_path
         self.ttl = ttl
         self._lock = threading.RLock()

--- a/mcp_second_brain/tools/search_attachments.py
+++ b/mcp_second_brain/tools/search_attachments.py
@@ -53,7 +53,11 @@ class SearchAttachmentAdapter(BaseAdapter):
     def __init__(self, model_name: str = "attachment_search"):
         self.model_name = model_name
         settings = get_settings()
-        self.client = OpenAI(api_key=settings.openai_api_key)
+        api_key = settings.openai_api_key
+        if api_key:
+            self.client = OpenAI(api_key=api_key)
+        else:
+            self.client = None
 
     async def generate(
         self,
@@ -161,6 +165,8 @@ class SearchAttachmentAdapter(BaseAdapter):
         """Search a single vector store."""
         async with search_semaphore:  # Limit concurrent searches
             try:
+                if self.client is None:
+                    raise ValueError("OpenAI API key not configured")
                 # OpenAI search is synchronous, run in thread pool
                 loop = asyncio.get_event_loop()
                 response = await loop.run_in_executor(

--- a/tests/integration_mcp/test_basic_mcp.py
+++ b/tests/integration_mcp/test_basic_mcp.py
@@ -1,59 +1,64 @@
 """Basic MCP integration tests - just verify tools can be called."""
+
 import pytest
 from mcp.types import TextContent
 import json
 
-# Use anyio for better async handling - but only with asyncio backend  
+# Use anyio for better async handling - but only with asyncio backend
 # This prevents "ModuleNotFoundError: No module named 'trio'" errors
 pytestmark = [
     pytest.mark.anyio,
-    pytest.mark.parametrize("anyio_backend", ["asyncio"], indirect=True)
+    pytest.mark.parametrize("anyio_backend", ["asyncio"], indirect=True),
 ]
 
 
 class TestBasicMCP:
     """Simple tests that MCP protocol works."""
-    
+
     async def test_list_models_callable(self, mcp_server):
         """Test that list_models can be called and returns expected type."""
         from fastmcp import Client
         from fastmcp.client import FastMCPTransport
-        
+
         # Create client within test to avoid async teardown issues
         transport = FastMCPTransport(mcp_server)
         async with Client(transport) as client:
             # Call the tool
             result = await client.call_tool("list_models")
-            
+
             # list_models returns a list of TextContent objects
             assert isinstance(result, list)
             assert len(result) > 0
-            
+
             # Each item should be parseable as JSON
             for item in result:
                 assert isinstance(item, TextContent)
                 model_data = json.loads(item.text)
                 assert "id" in model_data
                 assert "model" in model_data
-    
+
     async def test_gemini_tool_callable(self, mcp_server):
         """Test that a model tool can be called."""
         from fastmcp import Client
         from fastmcp.client import FastMCPTransport
-        
+
         transport = FastMCPTransport(mcp_server)
         async with Client(transport) as client:
-            result = await client.call_tool("chat_with_gemini25_pro", {
-                "instructions": "test",
-                "output_format": "json", 
-                "context": []
-            })
-            
+            result = await client.call_tool(
+                "chat_with_gemini25_pro",
+                {
+                    "instructions": "test",
+                    "output_format": "json",
+                    "context": [],
+                    "session_id": "mcp-gemini",
+                },
+            )
+
             # Tools return lists of TextContent
             assert isinstance(result, list)
             assert len(result) == 1
             assert isinstance(result[0], TextContent)
-            
+
             # Mock should return JSON (but handle if it doesn't)
             try:
                 data = json.loads(result[0].text)
@@ -61,21 +66,21 @@ class TestBasicMCP:
             except json.JSONDecodeError:
                 # If not JSON, just verify we got a response
                 assert len(result[0].text) > 0
-    
+
     async def test_vector_store_callable(self, mcp_server):
         """Test vector store tool."""
         from fastmcp import Client
         from fastmcp.client import FastMCPTransport
-        
+
         transport = FastMCPTransport(mcp_server)
         async with Client(transport) as client:
-            result = await client.call_tool("create_vector_store_tool", {
-                "files": ["/tmp/test.txt"]
-            })
-            
+            result = await client.call_tool(
+                "create_vector_store_tool", {"files": ["/tmp/test.txt"]}
+            )
+
             # This tool also returns a list
             assert isinstance(result, list)
             assert len(result) == 1
-            
+
             data = json.loads(result[0].text)
             assert "vector_store_id" in data

--- a/tests/internal/test_error_handling.py
+++ b/tests/internal/test_error_handling.py
@@ -1,28 +1,30 @@
 """
 Integration tests for error handling scenarios.
 """
+
 import pytest
 import json
 from unittest.mock import patch
 from mcp_second_brain.tools.executor import executor
 from mcp_second_brain.tools.registry import get_tool
+
 # Import definitions to ensure tools are registered
 import mcp_second_brain.tools.definitions  # noqa: F401
 
 
 class TestErrorHandlingIntegration:
     """Test error handling across the system."""
-    
+
     @pytest.mark.asyncio
     async def test_missing_api_key_error(self):
         """Test error when API key is missing."""
         from mcp_second_brain.config import get_settings
-        
+
         # Clear the settings cache
         get_settings.cache_clear()
-        
+
         try:
-            with patch.dict('os.environ', {'OPENAI_API_KEY': ''}, clear=False):
+            with patch.dict("os.environ", {"OPENAI_API_KEY": ""}, clear=False):
                 # Try to use OpenAI tool without key
                 # With mock adapter, missing API key won't raise an error
                 # The mock adapter doesn't check for API keys
@@ -34,7 +36,7 @@ class TestErrorHandlingIntegration:
                     instructions="Test",
                     output_format="text",
                     context=[],
-                    session_id="test"
+                    session_id="test",
                 )
                 # Should get mock response even without API key
                 data = json.loads(result)
@@ -42,7 +44,7 @@ class TestErrorHandlingIntegration:
         finally:
             # Clear cache again to avoid affecting other tests
             get_settings.cache_clear()
-    
+
     @pytest.mark.asyncio
     async def test_invalid_model_name(self, mock_adapter_error):
         """Test error with invalid model configuration."""
@@ -57,9 +59,9 @@ class TestErrorHandlingIntegration:
                     instructions="Test",
                     output_format="text",
                     context=[],
-                    session_id="test"
+                    session_id="test",
                 )
-    
+
     @pytest.mark.asyncio
     async def test_network_timeout(self, mock_adapter_error):
         """Test handling of network timeouts."""
@@ -74,16 +76,16 @@ class TestErrorHandlingIntegration:
                     instructions="Test",
                     output_format="text",
                     context=[],
-                    session_id="test"
+                    session_id="test",
                 )
-    
+
     @pytest.mark.asyncio
     async def test_rate_limit_error(self, mock_adapter_error):
         """Test handling of rate limit errors."""
         # Create a custom error with status_code attribute
         error = Exception("Rate limit exceeded")
         error.status_code = 429
-        
+
         with mock_adapter_error(error):
             with pytest.raises(Exception, match="Rate limit"):
                 tool_metadata = get_tool("chat_with_o3")
@@ -94,9 +96,9 @@ class TestErrorHandlingIntegration:
                     instructions="Test",
                     output_format="text",
                     context=[],
-                    session_id="test"
+                    session_id="test",
                 )
-    
+
     @pytest.mark.asyncio
     async def test_invalid_parameter_types(self):
         """Test type validation for parameters."""
@@ -109,9 +111,10 @@ class TestErrorHandlingIntegration:
                 tool_metadata,
                 instructions="Test",
                 output_format="text",
-                context="not-a-list"  # Should be list
+                context="not-a-list",  # Should be list
+                session_id="error-test",
             )
-        
+
         # Wrong type for temperature
         with pytest.raises(TypeError, match="temperature.*expected.*float"):
             tool_metadata = get_tool("chat_with_gemini25_flash")
@@ -122,9 +125,10 @@ class TestErrorHandlingIntegration:
                 instructions="Test",
                 output_format="text",
                 context=[],
-                temperature="high"  # Should be float
+                temperature="high",  # Should be float
+                session_id="error-test",
             )
-    
+
     @pytest.mark.asyncio
     async def test_file_not_found_in_context(self, parse_adapter_response):
         """Test handling of non-existent files in context."""
@@ -136,35 +140,38 @@ class TestErrorHandlingIntegration:
             tool_metadata,
             instructions="Analyze these files",
             output_format="text",
-            context=["/path/that/does/not/exist.py"]
+            context=["/path/that/does/not/exist.py"],
+            session_id="file-missing",
         )
-        
+
         # Should still work with MockAdapter
         data = parse_adapter_response(result)
         assert data["mock"] is True
         assert data["model"] == "gemini-2.5-flash"
-    
+
     @pytest.mark.asyncio
-    async def test_oversized_prompt(self, tmp_path, parse_adapter_response, mock_openai_client):
+    async def test_oversized_prompt(
+        self, tmp_path, parse_adapter_response, mock_openai_client
+    ):
         """Test handling of prompts that exceed model limits."""
         # Create a massive context
         huge_file = tmp_path / "huge.txt"
         huge_file.write_text("x" * 10_000_000)  # 10MB file
-        
+
         # MockAdapter should handle this gracefully
         tool_metadata = get_tool("chat_with_o3")
         if not tool_metadata:
             raise ValueError("Tool chat_with_o3 not found")
-        
+
         # With huge files, the system should automatically use vector store
         result = await executor.execute(
             tool_metadata,
             instructions="Analyze",
             output_format="text",
             context=[str(huge_file)],
-            session_id="test"
+            session_id="test",
         )
-        
+
         # MockAdapter will return JSON showing it processed the request
         data = parse_adapter_response(result)
         assert data["mock"] is True
@@ -173,12 +180,14 @@ class TestErrorHandlingIntegration:
         # The MockAdapter itself doesn't handle vector stores
         # Just verify the request went through successfully
         assert "Analyze" in data["prompt_preview"]
-    
+
     @pytest.mark.asyncio
     async def test_malformed_response_from_api(self, mock_adapter_error):
         """Test handling of malformed API responses."""
         # Simulate adapter returning None or malformed data
-        with mock_adapter_error(AttributeError("'NoneType' object has no attribute 'output_text'")):
+        with mock_adapter_error(
+            AttributeError("'NoneType' object has no attribute 'output_text'")
+        ):
             with pytest.raises(AttributeError):
                 tool_metadata = get_tool("chat_with_o3")
                 if not tool_metadata:
@@ -188,16 +197,19 @@ class TestErrorHandlingIntegration:
                     instructions="Test",
                     output_format="text",
                     context=[],
-                    session_id="test"
+                    session_id="test",
                 )
-    
+
     @pytest.mark.asyncio
     async def test_adapter_initialization_failure(self):
         """Test handling of adapter initialization failures."""
         # Patch get_adapter to return an error
-        with patch('mcp_second_brain.adapters.get_adapter') as mock_get_adapter:
-            mock_get_adapter.return_value = (None, "Failed to initialize adapter: Test error")
-            
+        with patch("mcp_second_brain.adapters.get_adapter") as mock_get_adapter:
+            mock_get_adapter.return_value = (
+                None,
+                "Failed to initialize adapter: Test error",
+            )
+
             # Executor returns an error string when adapter init fails
             tool_metadata = get_tool("chat_with_gemini25_flash")
             if not tool_metadata:
@@ -206,40 +218,48 @@ class TestErrorHandlingIntegration:
                 tool_metadata,
                 instructions="Test",
                 output_format="text",
-                context=[]
+                context=[],
+                session_id="init-fail",
             )
             assert "Failed to initialize adapter" in result
-    
+
     @pytest.mark.asyncio
-    async def test_concurrent_error_isolation(self, parse_adapter_response, mock_adapter_error):
+    async def test_concurrent_error_isolation(
+        self, parse_adapter_response, mock_adapter_error
+    ):
         """Test that errors in one tool don't affect others."""
         import asyncio
         from unittest.mock import patch, MagicMock
-        
+
         # Run both concurrently - one succeeds, one fails
         o3_metadata = get_tool("chat_with_o3")
         gemini_metadata = get_tool("chat_with_gemini25_flash")
         if not o3_metadata or not gemini_metadata:
             raise ValueError("Required tools not found")
-        
+
         # Create separate mock instances for each adapter
         from unittest.mock import AsyncMock
+
         o3_mock = MagicMock()
         gemini_mock = MagicMock()
-        
+
         # O3 succeeds (generate is async)
-        o3_mock.generate = AsyncMock(return_value=json.dumps({
-            "mock": True,
-            "model": "o3",
-            "prompt_preview": "Should succeed",
-            "prompt_length": 100,
-            "vector_store_ids": None,
-            "adapter_kwargs": {}
-        }))
-        
+        o3_mock.generate = AsyncMock(
+            return_value=json.dumps(
+                {
+                    "mock": True,
+                    "model": "o3",
+                    "prompt_preview": "Should succeed",
+                    "prompt_length": 100,
+                    "vector_store_ids": None,
+                    "adapter_kwargs": {},
+                }
+            )
+        )
+
         # Gemini fails (generate is async)
         gemini_mock.generate = AsyncMock(side_effect=Exception("Vertex failed"))
-        
+
         # Patch get_adapter to return our specific mocks
         def mock_get_adapter(adapter_key, model_name):
             if adapter_key == "openai":
@@ -247,31 +267,34 @@ class TestErrorHandlingIntegration:
             elif adapter_key == "vertex":
                 return gemini_mock, None
             return None, f"Unknown adapter: {adapter_key}"
-        
-        with patch('mcp_second_brain.adapters.get_adapter', side_effect=mock_get_adapter):
+
+        with patch(
+            "mcp_second_brain.adapters.get_adapter", side_effect=mock_get_adapter
+        ):
             tasks = [
                 executor.execute(
                     o3_metadata,
                     instructions="Should succeed",
                     output_format="text",
                     context=[],
-                    session_id="test"
+                    session_id="test",
                 ),
                 executor.execute(
                     gemini_metadata,
                     instructions="Should fail",
                     output_format="text",
-                    context=[]
-                )
+                    context=[],
+                    session_id="gemini-fail",
+                ),
             ]
-            
+
             results = await asyncio.gather(*tasks, return_exceptions=True)
-            
+
             # First should succeed
             data = parse_adapter_response(results[0])
             assert data["mock"] is True
             assert data["model"] == "o3"
-            
+
             # Second should fail
             assert isinstance(results[1], Exception)
             assert "Vertex failed" in str(results[1])

--- a/tests/internal/test_tool_execution.py
+++ b/tests/internal/test_tool_execution.py
@@ -19,6 +19,7 @@ class TestToolExecutionIntegration:
             instructions="Analyze the Python files in this project",
             output_format="bullet points",
             context=[str(temp_project)],
+            session_id="gemini-real-files",
         )
 
         # With mock adapter, we get JSON metadata
@@ -195,6 +196,7 @@ class TestToolExecutionIntegration:
                 instructions=f"Task {i}",
                 output_format="text",
                 context=[],
+                session_id=f"gemini-{i}",
             )
             for i in range(3)
         ]

--- a/tests/unit/test_tool_executor.py
+++ b/tests/unit/test_tool_executor.py
@@ -60,14 +60,15 @@ class TestToolExecutor:
                     output_format="markdown",
                     context=[str(test_file)],
                     temperature=0.5,
+                    session_id="gemini-test",
                 )
 
                 # Check that our mock was used
-                mock_get_adapter.assert_called_once()
+                assert mock_get_adapter.called
 
         # Verify adapter was called with correct params
-        mock_adapter.generate.assert_called_once()
-        call_args = mock_adapter.generate.call_args
+        assert mock_adapter.generate.call_count >= 1
+        call_args = mock_adapter.generate.call_args_list[0]
 
         # Check prompt was built
         prompt = call_args[1]["prompt"]
@@ -155,6 +156,7 @@ class TestToolExecutor:
                 metadata,
                 instructions="Test",
                 # Missing output_format and context
+                session_id="missing-param",
             )
 
     @pytest.mark.asyncio
@@ -182,6 +184,10 @@ class TestToolExecutor:
             # The executor returns error message instead of raising
             metadata = get_tool("chat_with_gemini25_flash")
             result = await executor.execute(
-                metadata, instructions="Test", output_format="text", context=[]
+                metadata,
+                instructions="Test",
+                output_format="text",
+                context=[],
+                session_id="adapter-error",
             )
             assert "Error: Failed to initialize adapter" in result


### PR DESCRIPTION
## Summary
- make `session_id` required across tool definitions
- adjust unit and integration tests to supply a session_id
- relax adapter call assertions to allow memory calls

## Testing
- `pre-commit run --files mcp_second_brain/tools/definitions.py tests/integration_mcp/test_basic_mcp.py tests/internal/test_error_handling.py tests/internal/test_tool_execution.py tests/unit/test_tool_executor.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f0ff3445c83318ffac1c77429871c