### PR TITLE
fix: Fix test_session_debug timeout by using correct parameter format

### DIFF
--- a/tests/e2e/test_session_debug.py
+++ b/tests/e2e/test_session_debug.py
@@ -18,20 +18,28 @@ class TestSessionDebug:
         session_id = f"debug-session-{uuid.uuid4().hex[:8]}"
 
         # First message
-        # Try different parameter formats
-        # Method 1: Direct parameter specification
+        args1 = {
+            "instructions": "Remember this: The secret word is BANANA. Just say OK.",
+            "output_format": "text",
+            "context": [],
+            "session_id": session_id,
+        }
         output1 = claude_code(
-            f'Use second-brain chat_with_gpt4_1 with instructions="Remember this: The secret word is BANANA. Just say OK.", '
-            f'output_format="text", context=[], and session_id="{session_id}"'
+            f"Use second-brain chat_with_gpt4_1 with {json.dumps(args1)}"
         )
         print("\n=== TURN 1 ===")
         print(f"Session ID: {session_id}")
         print(f"Output: {output1.strip()}")
 
         # Second message - should remember
+        args2 = {
+            "instructions": "What is the secret word? Just say the word.",
+            "output_format": "text",
+            "context": [],
+            "session_id": session_id,
+        }
         output2 = claude_code(
-            f'Use second-brain chat_with_gpt4_1 with instructions="What is the secret word? Just say the word.", '
-            f'output_format="text", context=[], and session_id="{session_id}"'
+            f"Use second-brain chat_with_gpt4_1 with {json.dumps(args2)}"
         )
         print("\n=== TURN 2 ===")
         print(f"Session ID: {session_id}")


### PR DESCRIPTION
## Summary
- Fixed test_session_debug.py timing out in GitHub Actions due to incorrect parameter format
- Test was using string concatenation instead of JSON format for tool parameters
- This caused the parser to fail and treat the entire command as plain text

## Root Cause
The test was using an incorrect format:
```python
f'Use second-brain chat_with_gpt4_1 with instructions="...", output_format="text", context=[], and session_id="{session_id}"'
```

Instead of the correct JSON format used by other tests:
```python
f"Use second-brain chat_with_gpt4_1 with {json.dumps(args1)}"
```

## Changes
- Updated test_simple_session_gpt4 to use JSON format with dictionaries for parameters
- This matches the format used in all other working E2E tests
- No changes needed to test_simple_session_o3 as it was already using the correct format

## Test Plan
- [x] Pre-commit hooks pass (ruff, mypy, pytest)
- [ ] E2E tests pass in GitHub Actions

🤖 Generated with [Claude Code](https://claude.ai/code)