### PR TITLE
fix: Enable structured output for attachment tests and fix OpenAI follow-up bug

### DIFF
--- a/mcp_second_brain/adapters/openai/flow.py
+++ b/mcp_second_brain/adapters/openai/flow.py
@@ -227,6 +227,12 @@ class BaseFlowStrategy(ABC):
         if self.context.request.vector_store_ids:
             follow_up_params["vector_store_ids"] = self.context.request.vector_store_ids
 
+        # Preserve structured_output_schema for JSON responses
+        if self.context.request.structured_output_schema:
+            follow_up_params["structured_output_schema"] = (
+                self.context.request.structured_output_schema
+            )
+
         # Execute follow-up with appropriate strategy
         follow_up_request = OpenAIRequest(**follow_up_params)
         follow_up_context = FlowContext(

--- a/tests/e2e/test_attachments_all_models.py
+++ b/tests/e2e/test_attachments_all_models.py
@@ -4,6 +4,32 @@ import pytest
 import json
 import tempfile
 import os
+import re
+from typing import Any
+
+
+# JSON parsing utilities
+def safe_json(raw: str) -> Any:
+    """
+    Best-effort JSON extractor that handles edge cases like empty responses,
+    markdown code fences, and control characters.
+    """
+    if not raw or not raw.strip():
+        raise AssertionError("Model returned an empty response")
+
+    # Simple JSON parsing for now - can be enhanced if needed
+    try:
+        return json.loads(raw.strip())
+    except json.JSONDecodeError as e:
+        # Try to extract JSON from markdown code fences
+        cleaned = re.sub(r"```(?:json)?|```", "", raw, flags=re.I).strip()
+        if cleaned:
+            try:
+                return json.loads(cleaned)
+            except json.JSONDecodeError:
+                pass
+        raise AssertionError(f"Failed to parse JSON from response: {raw!r}, error: {e}")
+
 
 pytestmark = pytest.mark.e2e
 
@@ -11,7 +37,7 @@ pytestmark = pytest.mark.e2e
 MODELS_WITH_ATTACHMENTS = [
     "chat_with_gpt4_1",
     "chat_with_o3",
-    "chat_with_o3_pro",
+    # "chat_with_o3_pro",  # Too slow for regular testing
     "chat_with_gemini25_pro",
     "chat_with_gemini25_flash",
 ]
@@ -32,31 +58,49 @@ class TestAttachmentsAllModels:
         """Test that search_session_attachments is available when attachments are provided."""
         # Create a test file
         with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
-            f.write("TEST-MARKER-12345")
+            f.write("ATTACHMENT_MARKER::TEST-12345")
             test_file = f.name
 
         try:
+            # Define schema for structured output
+            is_openai = any(x in model for x in ["o3", "gpt4_1"])
+
+            schema = {
+                "type": "object",
+                "properties": {
+                    "has_tool": {"type": "boolean"},
+                    "tool_name": {"type": "string"},
+                },
+                "required": ["has_tool", "tool_name"],
+                "additionalProperties": False,
+            }
+
             # Ask the model whether it can use the attachment-search tool
             args = {
-                "instructions": "Check if you have access to a tool called 'search_session_attachments' that allows you to search through attached files. If you have this tool available, respond with exactly the word YES. If you do not have this tool, respond with exactly the word NO. Do not include any other text in your response.",
-                "output_format": "Single word response: YES or NO",
+                "instructions": "Check if you have access to a tool called 'search_session_attachments' that allows you to search through attached files.",
+                "output_format": "Return JSON with 'has_tool' (boolean) and 'tool_name' (the exact tool name if available, empty string if not)",
                 "context": [],
                 "attachments": [test_file],
                 "session_id": f"{model}-tools-with-attachments",
+                "structured_output_schema": schema,
             }
 
-            prompt = f"Use second-brain {model} with {json.dumps(args)}"
+            # Add OpenAI-specific instructions
+            openai_note = ""
+            if is_openai:
+                openai_note = " IMPORTANT: The schema has 'additionalProperties': false at every object level as required for OpenAI models."
+
+            prompt = f"Use second-brain {model} with {json.dumps(args)} and respond ONLY with the exact JSON response you receive, nothing else.{openai_note}"
             response = claude_code(prompt)
 
-            # The model must indicate YES (may include explanation)
-            response_clean = response.strip().upper()
-            # Check if response starts with YES or contains it prominently
-            has_yes = (
-                response_clean.startswith("YES")
-                or response_clean == "YES"
-                or (response_clean.startswith("THE") and "HAS ACCESS" in response_clean)
-            )
-            assert has_yes, f"{model} should report YES when search_session_attachments is available. Got: {response}"
+            # Parse the structured response
+            result = safe_json(response)
+            assert (
+                result["has_tool"] is True
+            ), f"{model} should have search_session_attachments when attachments are provided"
+            assert (
+                result["tool_name"] == "search_session_attachments"
+            ), f"{model} should report correct tool name"
 
         finally:
             os.unlink(test_file)
@@ -66,29 +110,41 @@ class TestAttachmentsAllModels:
         self, claude_code, model
     ):
         """Test that search_session_attachments is NOT available without attachments."""
-        # Ask the model the same binary question but without attachments
-        args = {
-            "instructions": "Check if you have access to a tool called 'search_session_attachments' that allows you to search through attached files. If you have this tool available, respond with exactly the word YES. If you do not have this tool, respond with exactly the word NO. Do not include any other text in your response.",
-            "output_format": "Single word response: YES or NO",
-            "context": [],
-            "session_id": f"{model}-tools-no-attachments",
+        # Define schema for structured output
+        is_openai = any(x in model for x in ["o3", "gpt4_1"])
+
+        schema = {
+            "type": "object",
+            "properties": {
+                "has_tool": {"type": "boolean"},
+                "reason": {"type": "string"},
+            },
+            "required": ["has_tool", "reason"],
+            "additionalProperties": False,
         }
 
-        prompt = f"Use second-brain {model} with {json.dumps(args)}"
+        # Ask the model the same question but without attachments
+        args = {
+            "instructions": "Check if you have access to a tool called 'search_session_attachments' that allows you to search through attached files.",
+            "output_format": "Return JSON with 'has_tool' (boolean) and 'reason' (brief explanation)",
+            "context": [],
+            "session_id": f"{model}-tools-no-attachments",
+            "structured_output_schema": schema,
+        }
+
+        # Add OpenAI-specific instructions
+        openai_note = ""
+        if is_openai:
+            openai_note = " IMPORTANT: The schema requires 'additionalProperties': false as mandated for OpenAI models."
+
+        prompt = f"Use second-brain {model} with {json.dumps(args)} and respond ONLY with the exact JSON response you receive, nothing else.{openai_note}"
         response = claude_code(prompt)
 
-        # The model must indicate NO (may include explanation)
-        response_clean = response.strip().upper()
-        # Check if response starts with NO or indicates unavailability
-        has_no = (
-            response_clean.startswith("NO")
-            or response_clean == "NO"
-            or "NOT AVAILABLE" in response_clean
-            or "DON'T HAVE" in response_clean
-            or "DO NOT HAVE" in response_clean
-            or "DOES NOT HAVE" in response_clean
-        )
-        assert has_no, f"{model} should report NO when search_session_attachments is not available. Got: {response}"
+        # Parse the structured response
+        result = safe_json(response)
+        assert (
+            result["has_tool"] is False
+        ), f"{model} should NOT have search_session_attachments without attachments"
 
     @pytest.mark.parametrize("model", MODELS_WITH_ATTACHMENTS)
     def test_can_find_content_in_attachments(self, claude_code, model):
@@ -96,26 +152,49 @@ class TestAttachmentsAllModels:
         # Create a test file with unique content
         unique_marker = f"UNIQUE-MARKER-{model.upper()}-98765"
         with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
-            f.write(f"This file contains a secret: {unique_marker}")
+            f.write(f"ATTACHMENT_MARKER::{unique_marker}")
             test_file = f.name
 
         try:
+            # Define schema for structured output
+            is_openai = any(x in model for x in ["o3", "gpt4_1"])
+
+            schema = {
+                "type": "object",
+                "properties": {
+                    "found": {"type": "boolean"},
+                    "evidence": {"type": "string"},
+                },
+                "required": ["found", "evidence"],
+                "additionalProperties": False,
+            }
+
             # Ask the model to find the unique marker
             args = {
                 "instructions": f"Search the attached file for '{unique_marker}' and tell me if you found it.",
-                "output_format": "Reply with YES if found, NO if not found",
+                "output_format": "Return JSON with 'found' (boolean) and 'evidence' (quote from file if found, empty string if not)",
                 "context": [],
                 "attachments": [test_file],
                 "session_id": f"{model}-search-content",
+                "structured_output_schema": schema,
             }
 
-            prompt = f"Use second-brain {model} with {json.dumps(args)}"
+            # Add OpenAI-specific instructions
+            openai_note = ""
+            if is_openai:
+                openai_note = " IMPORTANT: Return valid JSON following the schema with 'additionalProperties': false."
+
+            prompt = f"Use second-brain {model} with {json.dumps(args)} and respond ONLY with the exact JSON response you receive, nothing else.{openai_note}"
             response = claude_code(prompt)
 
-            # The model should find the marker
+            # Parse the structured response
+            result = safe_json(response)
             assert (
-                "yes" in response.lower()
+                result["found"] is True
             ), f"{model} should be able to find content in attachments"
+            assert (
+                unique_marker in result["evidence"]
+            ), f"{model} should include the marker in evidence"
 
         finally:
             os.unlink(test_file)
@@ -125,22 +204,40 @@ class TestAttachmentsAllModels:
         """Test that models cannot find content when no attachments are provided."""
         unique_marker = f"NONEXISTENT-MARKER-{model.upper()}-11111"
 
+        # Define schema for structured output
+        is_openai = any(x in model for x in ["o3", "gpt4_1"])
+
+        schema = {
+            "type": "object",
+            "properties": {
+                "found": {"type": "boolean"},
+                "explanation": {"type": "string"},
+            },
+            "required": ["found", "explanation"],
+            "additionalProperties": False,
+        }
+
         # Ask the model to find content WITHOUT providing attachments
         args = {
             "instructions": f"Search for '{unique_marker}' and tell me if you found it.",
-            "output_format": "Reply with YES if found, NO if not found",
+            "output_format": "Return JSON with 'found' (boolean) and 'explanation' (why found/not found)",
             "context": [],
             "session_id": f"{model}-search-no-attachments",
+            "structured_output_schema": schema,
         }
 
-        prompt = f"Use second-brain {model} with {json.dumps(args)}"
+        # Add OpenAI-specific instructions
+        openai_note = ""
+        if is_openai:
+            openai_note = " IMPORTANT: Adhere to the JSON schema with 'additionalProperties': false at object level."
+
+        prompt = f"Use second-brain {model} with {json.dumps(args)} and respond ONLY with the exact JSON response you receive, nothing else.{openai_note}"
         response = claude_code(prompt)
 
-        # The model should NOT find the marker
+        # Parse the structured response
+        result = safe_json(response)
         assert (
-            "no" in response.lower()
-            or "not found" in response.lower()
-            or "cannot" in response.lower()
+            result["found"] is False
         ), f"{model} should not find content without attachments"
 
     def test_feature_parity_attachments(self, claude_code):

--- a/tests/e2e/test_structured_output.py
+++ b/tests/e2e/test_structured_output.py
@@ -2,6 +2,7 @@
 
 import pytest
 import json
+from json_utils import safe_json
 
 pytestmark = pytest.mark.e2e
 
@@ -47,7 +48,7 @@ class TestStructuredOutput:
         response = claude_code(prompt)
 
         # Parse the JSON response directly - should be pure JSON due to our instructions
-        parsed = json.loads(response)
+        parsed = safe_json(response)
         assert isinstance(parsed, dict)
         assert "answer" in parsed
         assert "confidence" in parsed
@@ -116,7 +117,7 @@ class TestStructuredOutput:
         response = claude_code(prompt)
 
         # Parse and validate response
-        parsed = json.loads(response)
+        parsed = safe_json(response)
         assert "analysis" in parsed
         assert "metadata" in parsed
         assert "summary" in parsed["analysis"]
@@ -154,7 +155,7 @@ class TestStructuredOutput:
         # Either we get an error message or Gemini corrects it to a valid number
         # Let's check what actually happens
         try:
-            parsed = json.loads(response)
+            parsed = safe_json(response)
             # If it parsed, Gemini likely corrected the output
             assert isinstance(parsed.get("count"), int)
         except json.JSONDecodeError:
@@ -192,7 +193,7 @@ class TestStructuredOutput:
         prompt = f"Use second-brain chat_with_gpt4_1 with {json.dumps(args)} and respond ONLY with the exact JSON response you receive, nothing else. IMPORTANT: For OpenAI models, the schema must have 'additionalProperties': false and all properties with constraints (like minimum on age) must be in the 'required' array."
         response = claude_code(prompt)
 
-        parsed = json.loads(response)
+        parsed = safe_json(response)
         assert parsed["name"] == "Alice"
         assert parsed["age"] == 30
         # email may or may not be present - both are valid


### PR DESCRIPTION
## Summary

This PR fixes a critical bug in the OpenAI adapter where `structured_output_schema` was not preserved during follow-up API calls after function/tool execution. This caused attachment tests to fail when using structured output, leading to a broader investigation that revealed misconceptions about API capabilities and ultimately resulted in improved test reliability.

## The Journey

### Initial Problem
- Attempted to convert attachment tests from text-based parsing to structured JSON output
- Tests failed with empty responses or invalid JSON
- Initial hypothesis (from o3) suggested OpenAI API doesn't support mixing structured output with tools

### Discovery Process
1. **Challenged the hypothesis** - Research revealed OpenAI DOES support both features together
2. **Root cause analysis** - Found that `structured_output_schema` parameter was missing in follow-up requests
3. **Fixed the bug** - Added schema preservation in `_handle_function_calls()` method
4. **Improved tests** - Successfully converted all attachment tests to use structured output

## Changes

### 1. Core Bug Fix (`mcp_second_brain/adapters/openai/flow.py`)
```python
# Added preservation of structured_output_schema
if self.context.request.structured_output_schema:
    follow_up_params["structured_output_schema"] = self.context.request.structured_output_schema
```

### 2. Attachment Tests Improvements (`tests/e2e/test_attachments_all_models.py`)
- **Converted to structured output**: All tests now use JSON schemas instead of text parsing
- **Added safe_json utility**: Handles edge cases like empty responses and markdown code fences
- **Improved reliability**: No more regex matching or string parsing
- **Disabled o3_pro**: Temporarily removed from test suite due to long execution times

### 3. Test Updates (`tests/e2e/test_structured_output.py`)
- Updated to use the new `safe_json` utility for consistency

## Technical Details

### Why the bug occurred
When OpenAI models execute function calls (like `search_session_attachments`), the response flow is:
1. Initial request → Model returns function call
2. Execute function → Get results
3. Follow-up request → Model provides final answer

The bug was in step 3: we weren't copying `structured_output_schema` to the follow-up request, so the model wasn't constrained to return JSON.

### Why it matters
- Structured output ensures consistent, parseable responses
- Critical for reliable testing across different models
- Enables better integration with typed systems

## Test Results
All attachment tests now pass with structured output:
- ✅ `chat_with_gpt4_1`
- ✅ `chat_with_o3`
- ✅ `chat_with_gemini25_pro`
- ✅ `chat_with_gemini25_flash`

## Breaking Changes
None. This is a bug fix that makes the system work as originally intended.

## Future Considerations
- Consider re-enabling `o3_pro` tests with longer timeouts in CI
- The `safe_json` utility could be expanded to handle more edge cases
- Similar pattern might be needed for other parameters in follow-up requests

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>