### PR TITLE
feat: Add composite keys to unified session cache for collision prevention

### DIFF
--- a/mcp_the_force/adapters/litellm_base.py
+++ b/mcp_the_force/adapters/litellm_base.py
@@ -59,16 +59,20 @@ class LiteLLMBaseAdapter:
         """
         pass
 
-    async def _load_session_history(self, session_id: str) -> List[Dict[str, Any]]:
+    async def _load_session_history(
+        self, project: str, tool: str, session_id: str
+    ) -> List[Dict[str, Any]]:
         """Load session history from cache.
 
         Args:
+            project: Project identifier
+            tool: Tool identifier
             session_id: Session identifier
 
         Returns:
             Conversation history in Responses API format
         """
-        history = await UnifiedSessionCache.get_history(session_id)
+        history = await UnifiedSessionCache.get_history(project, tool, session_id)
         if history:
             logger.debug(
                 f"[{self.display_name}] Loaded {len(history)} items from session {session_id}"
@@ -300,6 +304,8 @@ class LiteLLMBaseAdapter:
 
             # Save to cache
             await UnifiedSessionCache.set_history(
+                ctx.project,
+                ctx.tool,
                 ctx.session_id,
                 final_conversation,
             )
@@ -355,7 +361,9 @@ class LiteLLMBaseAdapter:
             # Load session history if needed
             conversation_input = []
             if ctx.session_id:
-                conversation_input = await self._load_session_history(ctx.session_id)
+                conversation_input = await self._load_session_history(
+                    ctx.project, ctx.tool, ctx.session_id
+                )
 
             # Build conversation for current turn
             conversation_input.extend(

--- a/mcp_the_force/adapters/mock_adapter.py
+++ b/mcp_the_force/adapters/mock_adapter.py
@@ -189,7 +189,9 @@ class MockAdapter:
             from ..unified_session_cache import UnifiedSessionCache
 
             # Save the conversation history to the unified cache
-            await UnifiedSessionCache.set_history(session_id, history)
+            await UnifiedSessionCache.set_history(
+                ctx.project, ctx.tool, session_id, history
+            )
 
         # Return dict format as per MCPAdapter protocol
         return {"content": mock_response}

--- a/mcp_the_force/adapters/openai/adapter.py
+++ b/mcp_the_force/adapters/openai/adapter.py
@@ -86,7 +86,7 @@ class OpenAIProtocolAdapter:
             previous_response_id = None
             if ctx.session_id:
                 previous_response_id = await UnifiedSessionCache.get_response_id(
-                    ctx.session_id
+                    ctx.project, ctx.tool, ctx.session_id
                 )
                 if previous_response_id:
                     logger.info(
@@ -129,11 +129,11 @@ class OpenAIProtocolAdapter:
             # Store response_id in session for continuity
             if ctx.session_id and "response_id" in result:
                 await UnifiedSessionCache.set_response_id(
-                    ctx.session_id, result["response_id"]
+                    ctx.project, ctx.tool, ctx.session_id, result["response_id"]
                 )
                 # Also store that we're using OpenAI native format
                 await UnifiedSessionCache.set_api_format(
-                    ctx.session_id, "openai_native"
+                    ctx.project, ctx.tool, ctx.session_id, "openai_native"
                 )
                 logger.debug(
                     f"Saved response_id {result['response_id']} for session {ctx.session_id}"

--- a/mcp_the_force/adapters/protocol.py
+++ b/mcp_the_force/adapters/protocol.py
@@ -10,6 +10,8 @@ class CallContext:
     """Context passed to adapters during generation."""
 
     session_id: str
+    project: str
+    tool: str
     vector_store_ids: Optional[List[str]] = None
     tool_call_id: Optional[str] = None
     # Add more context as needed

--- a/tests/unit/adapters/test_grok_adapter_unit.py
+++ b/tests/unit/adapters/test_grok_adapter_unit.py
@@ -69,7 +69,11 @@ class TestGrokAdapterUnit:
                     structured_output_schema=None,
                 )
 
-                ctx = CallContext(session_id="test-session-simple")
+                ctx = CallContext(
+                    session_id="test-session-simple",
+                    project="test-project",
+                    tool="chat_with_grok4",
+                )
 
                 # Mock tool dispatcher with empty tools
                 mock_dispatcher = MagicMock()
@@ -86,7 +90,7 @@ class TestGrokAdapterUnit:
 
                 # Verify adapter called session cache correctly
                 mock_cache_class.get_history.assert_called_once_with(
-                    "test-session-simple"
+                    "test-project", "chat_with_grok4", "test-session-simple"
                 )
                 mock_cache_class.set_history.assert_called_once()
 
@@ -144,7 +148,9 @@ class TestGrokAdapterUnit:
                     structured_output_schema=None,
                 )
 
-                ctx = CallContext(session_id="")
+                ctx = CallContext(
+                    session_id="", project="test-project", tool="chat_with_grok4"
+                )
 
                 # Mock tool dispatcher that doesn't have the unknown tool
                 mock_dispatcher = MagicMock()
@@ -204,7 +210,11 @@ class TestGrokAdapterUnit:
                     structured_output_schema=None,
                 )
 
-                ctx = CallContext(session_id="test-session-123")
+                ctx = CallContext(
+                    session_id="test-session-123",
+                    project="test-project",
+                    tool="chat_with_grok4",
+                )
 
                 # Mock tool dispatcher with empty tools
                 mock_dispatcher = MagicMock()
@@ -218,10 +228,17 @@ class TestGrokAdapterUnit:
                 )
 
                 # Verify session cache was called with correct session ID
-                mock_cache_class.get_history.assert_called_once_with("test-session-123")
+                mock_cache_class.get_history.assert_called_once_with(
+                    "test-project", "chat_with_grok4", "test-session-123"
+                )
                 mock_cache_class.set_history.assert_called_once()
 
                 # Check that history was stored with correct session ID
                 call_args = mock_cache_class.set_history.call_args
-                session_id_arg = call_args[0][0]
+                # Arguments are now: project, tool, session_id, history
+                project_arg = call_args[0][0]
+                tool_arg = call_args[0][1]
+                session_id_arg = call_args[0][2]
+                assert project_arg == "test-project"
+                assert tool_arg == "chat_with_grok4"
                 assert session_id_arg == "test-session-123"

--- a/tests/unit/test_adapter_message_format_integrity.py
+++ b/tests/unit/test_adapter_message_format_integrity.py
@@ -129,7 +129,9 @@ async def test_format_preservation_through_full_cycle():
             mock_aresponses.return_value = mock_response
 
             # Execute
-            ctx = CallContext(session_id="test-session")
+            ctx = CallContext(
+                session_id="test-session", project="test-project", tool="test-tool"
+            )
             params = TestParams()
             tool_dispatcher = Mock()
             tool_dispatcher.get_tool_declarations.return_value = []
@@ -164,7 +166,9 @@ async def test_format_preservation_through_full_cycle():
 
             # Verify saved conversation preserves format
             assert mock_cache.set_history.called
-            saved_messages = mock_cache.set_history.call_args[0][1]
+            saved_messages = mock_cache.set_history.call_args[0][
+                3
+            ]  # Now 4th argument after project, tool, session_id
 
             # Should have all messages plus assistant response
             assert len(saved_messages) == 7
@@ -211,7 +215,9 @@ async def test_no_format_assumptions():
                 ]
                 mock_aresponses.return_value = mock_response
 
-                ctx = CallContext(session_id="edge-test")
+                ctx = CallContext(
+                    session_id="edge-test", project="test-project", tool="test-tool"
+                )
                 params = TestParams()
 
                 await adapter.generate(
@@ -245,7 +251,7 @@ async def test_round_trip_integrity():
                 mock_cache.get_history = AsyncMock(return_value=conversation.copy())
                 saved_conversation = None
 
-                def capture_save(session_id, messages):
+                def capture_save(project, tool, session_id, messages):
                     nonlocal saved_conversation
                     saved_conversation = messages.copy()
                     return AsyncMock()()
@@ -259,7 +265,9 @@ async def test_round_trip_integrity():
                 ]
                 mock_aresponses.return_value = mock_response
 
-                ctx = CallContext(session_id="round-trip")
+                ctx = CallContext(
+                    session_id="round-trip", project="test-project", tool="test-tool"
+                )
                 params = TestParams()
 
                 await adapter.generate(
@@ -331,7 +339,9 @@ async def test_tool_call_format_preservation():
             tool_dispatcher.get_tool_declarations.return_value = []
             tool_dispatcher.execute = AsyncMock(return_value="Found 3 files")
 
-            ctx = CallContext(session_id="tool-test")
+            ctx = CallContext(
+                session_id="tool-test", project="test-project", tool="test-tool"
+            )
             params = TestParams()
 
             await adapter.generate(
@@ -403,7 +413,9 @@ async def test_content_type_variations():
                 mock_response.output = [Mock(type="message", content=[Mock(text="OK")])]
                 mock_aresponses.return_value = mock_response
 
-                ctx = CallContext(session_id="content-test")
+                ctx = CallContext(
+                    session_id="content-test", project="test-project", tool="test-tool"
+                )
 
                 await adapter.generate(
                     prompt="Test",

--- a/tests/unit/test_session_cache.py
+++ b/tests/unit/test_session_cache.py
@@ -24,6 +24,8 @@ async def test_basic_set_get():
 
         # Set a response ID
         session = UnifiedSession(
+            project="test-project",
+            tool="test-tool",
             session_id="test_session",
             updated_at=int(time.time()),
             provider_metadata={"response_id": "test_response"},
@@ -31,12 +33,12 @@ async def test_basic_set_get():
         await cache.set_session(session)
 
         # Get it back
-        result = await cache.get_session("test_session")
+        result = await cache.get_session("test-project", "test-tool", "test_session")
         assert result is not None
         assert result.provider_metadata.get("response_id") == "test_response"
 
         # Non-existent session returns None
-        result = await cache.get_session("nonexistent")
+        result = await cache.get_session("test-project", "test-tool", "nonexistent")
         assert result is None
 
         cache.close()
@@ -54,6 +56,8 @@ async def test_persistence():
         # First instance
         cache1 = _SQLiteUnifiedSessionCache(db_path=db_path, ttl=3600)
         session = UnifiedSession(
+            project="test-project",
+            tool="test-tool",
             session_id="persist_test",
             updated_at=int(time.time()),
             provider_metadata={"response_id": "persist_value"},
@@ -63,7 +67,7 @@ async def test_persistence():
 
         # Second instance should see the data
         cache2 = _SQLiteUnifiedSessionCache(db_path=db_path, ttl=3600)
-        result = await cache2.get_session("persist_test")
+        result = await cache2.get_session("test-project", "test-tool", "persist_test")
         assert result is not None
         assert result.provider_metadata.get("response_id") == "persist_value"
         cache2.close()
@@ -84,6 +88,8 @@ async def test_expiration(monkeypatch):
 
         with mock_clock(monkeypatch) as tick:
             session = UnifiedSession(
+                project="test-project",
+                tool="test-tool",
                 session_id="expire_test",
                 updated_at=int(time.time()),
                 provider_metadata={"response_id": "expire_value"},
@@ -91,7 +97,7 @@ async def test_expiration(monkeypatch):
             await cache.set_session(session)
 
             # Should exist immediately
-            result = await cache.get_session("expire_test")
+            result = await cache.get_session("test-project", "test-tool", "expire_test")
             assert result is not None
             assert result.provider_metadata.get("response_id") == "expire_value"
 
@@ -99,7 +105,7 @@ async def test_expiration(monkeypatch):
             tick(1.1)
 
             # Should be expired
-            result = await cache.get_session("expire_test")
+            result = await cache.get_session("test-project", "test-tool", "expire_test")
             assert result is None
 
         cache.close()
@@ -119,6 +125,8 @@ async def test_concurrent_access():
         async def write_many(prefix, count):
             for i in range(count):
                 session = UnifiedSession(
+                    project="test-project",
+                    tool="test-tool",
                     session_id=f"{prefix}_{i}",
                     updated_at=int(time.time()),
                     provider_metadata={"value": f"value_{i}"},
@@ -128,7 +136,9 @@ async def test_concurrent_access():
         async def read_many(prefix, count):
             results = []
             for i in range(count):
-                result = await cache.get_session(f"{prefix}_{i}")
+                result = await cache.get_session(
+                    "test-project", "test-tool", f"{prefix}_{i}"
+                )
                 results.append(result)
             return results
 
@@ -167,13 +177,15 @@ async def test_long_ids_rejected():
         # Session ID too long
         with pytest.raises(ValueError, match="session_id too long"):
             session = UnifiedSession(
+                project="test-project",
+                tool="test-tool",
                 session_id="x" * 1025,
                 updated_at=int(time.time()),
             )
             await cache.set_session(session)
 
         with pytest.raises(ValueError, match="session_id too long"):
-            await cache.get_session("x" * 1025)
+            await cache.get_session("test-project", "test-tool", "x" * 1025)
 
         cache.close()
     finally:
@@ -191,24 +203,35 @@ async def test_proxy_interface():
     append_session = f"append_test_{uuid.uuid4()}"
 
     # The unified_session_cache proxy should work with await
-    await unified_session_cache.set_response_id(proxy_session, "proxy_value")
-    result = await unified_session_cache.get_response_id(proxy_session)
+    await unified_session_cache.set_response_id(
+        "test-project", "test-tool", proxy_session, "proxy_value"
+    )
+    result = await unified_session_cache.get_response_id(
+        "test-project", "test-tool", proxy_session
+    )
     assert result == "proxy_value"
 
     # Test history methods
     await unified_session_cache.set_history(
-        history_session, [{"role": "user", "content": "Hello"}]
+        "test-project",
+        "test-tool",
+        history_session,
+        [{"role": "user", "content": "Hello"}],
     )
-    history = await unified_session_cache.get_history(history_session)
+    history = await unified_session_cache.get_history(
+        "test-project", "test-tool", history_session
+    )
     assert len(history) == 1
     assert history[0]["role"] == "user"
     assert history[0]["content"] == "Hello"
 
     # Test append methods
     await unified_session_cache.append_chat_message(
-        append_session, "assistant", "Hi there!"
+        "test-project", "test-tool", append_session, "assistant", "Hi there!"
     )
-    history = await unified_session_cache.get_history(append_session)
+    history = await unified_session_cache.get_history(
+        "test-project", "test-tool", append_session
+    )
     assert len(history) == 1
     assert history[0]["role"] == "assistant"
     assert history[0]["content"] == "Hi there!"
@@ -223,20 +246,27 @@ async def test_session_metadata():
     session_id = "metadata_test"
 
     # Set multiple metadata fields
-    session = UnifiedSession(
-        session_id=session_id,
-        updated_at=int(time.time()),
-        provider_metadata={
-            "response_id": "resp_123",
-            "api_format": "responses",
-            "deployment_id": "deploy_456",
-        },
+    # Use metadata methods instead of direct session access
+    await unified_session_cache.set_metadata(
+        "test-project", "test-tool", session_id, "response_id", "resp_123"
     )
-    await unified_session_cache.set_session(session)
+    await unified_session_cache.set_metadata(
+        "test-project", "test-tool", session_id, "api_format", "responses"
+    )
+    await unified_session_cache.set_metadata(
+        "test-project", "test-tool", session_id, "deployment_id", "deploy_456"
+    )
 
     # Get back and verify
-    result = await unified_session_cache.get_session(session_id)
-    assert result is not None
-    assert result.provider_metadata["response_id"] == "resp_123"
-    assert result.provider_metadata["api_format"] == "responses"
-    assert result.provider_metadata["deployment_id"] == "deploy_456"
+    response_id = await unified_session_cache.get_metadata(
+        "test-project", "test-tool", session_id, "response_id"
+    )
+    api_format = await unified_session_cache.get_metadata(
+        "test-project", "test-tool", session_id, "api_format"
+    )
+    deployment_id = await unified_session_cache.get_metadata(
+        "test-project", "test-tool", session_id, "deployment_id"
+    )
+    assert response_id == "resp_123"
+    assert api_format == "responses"
+    assert deployment_id == "deploy_456"


### PR DESCRIPTION
## Summary
- Implements proper database solution for session ID collision prevention
- Uses composite primary key (project, tool, session_id) instead of string manipulation
- Includes automatic migration for existing sessions

## Problem
Session IDs like "mypy-analysis" could collide across different projects and tools, potentially causing data corruption or security issues.

## Solution
Instead of the initially proposed string canonicalization approach (which was overengineered), this PR implements the proper solution:
- Add `project` and `tool` columns to the `unified_sessions` SQLite table
- Use composite primary key: `(project, tool, session_id)`
- All session operations now require all three components

## Changes
1. **Database schema update**:
   - Added `project` and `tool` columns to `unified_sessions` table
   - Changed primary key to composite `(project, tool, session_id)`
   - Added migration logic for existing sessions (defaults: project='default', tool='unknown')

2. **API updates**:
   - All `UnifiedSessionCache` methods now require `project` and `tool` parameters
   - `CallContext` protocol extended with `project` and `tool` fields
   - Executor determines project from config/working directory

3. **Adapter updates**:
   - OpenAI, Gemini (via LiteLLM), Grok, and Mock adapters updated
   - All adapters now pass project/tool context when accessing session cache

4. **Test updates**:
   - Fixed all unit tests to use new API
   - Fixed all integration tests
   - All tests passing

## Benefits
- Solves the problem at the database level where it belongs
- No string manipulation or hidden transformations
- Clean, maintainable solution
- Automatic migration preserves existing sessions

## Test plan
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Pre-commit hooks pass
- [x] Migration tested with existing database

🤖 Generated with [Claude Code](https://claude.ai/code)