### PR TITLE
feat(tools): Add integration test for tool loading

### DIFF
--- a/mcp_the_force/tools/autogen.py
+++ b/mcp_the_force/tools/autogen.py
@@ -11,12 +11,20 @@ import logging
 from .blueprint_registry import BLUEPRINTS
 from .factories import make_tool
 from ..adapters.registry import list_adapters
+from ..config import get_settings
 
 logger = logging.getLogger(__name__)
+
 
 # Import all adapter packages from the central registry
 # This ensures we have only ONE place where adapters are listed
 for adapter_key in list_adapters():
+    settings = get_settings()
+    provider_config = getattr(settings, adapter_key, None)
+    if provider_config and not provider_config.enabled:
+        logger.info(f"Skipping disabled adapter: {adapter_key}")
+        continue
+
     package = f"mcp_the_force.adapters.{adapter_key}"
     try:
         importlib.import_module(package)

--- a/tests/integration/test_tool_loading.py
+++ b/tests/integration/test_tool_loading.py
@@ -1,0 +1,64 @@
+import sys
+
+from mcp_the_force.tools.registry import list_tools, TOOL_REGISTRY
+
+
+def test_missing_openai_api_key_hides_tools(monkeypatch):
+    """
+    Given no OpenAI API key is configured,
+    When the tool registry is initialized,
+    Then OpenAI-based tools should not be available.
+    """
+    # Unload the autogen module to prevent premature tool registration
+    monkeypatch.delitem(sys.modules, "mcp_the_force.tools.autogen", raising=False)
+
+    # Clear the tool registry to ensure a clean state
+    TOOL_REGISTRY.clear()
+
+    # Use a custom config file that disables the openai provider
+    monkeypatch.setenv(
+        "MCP_CONFIG_FILE",
+        "/Users/luka/src/cc/gemini-vertex-improved/tests/integration/test_config.yaml",
+    )
+
+    # Reload the settings to reflect the change
+    from mcp_the_force.config import get_settings
+
+    get_settings.cache_clear()
+
+    # Re-import the autogen module to trigger tool registration
+
+    # List available tools
+    available_tools = list_tools()
+
+    # Assert that OpenAI tools are not in the registry
+    assert "chat_with_o3" not in available_tools
+
+
+def test_openai_api_key_enables_tools(monkeypatch):
+    """
+    Given an OpenAI API key is configured,
+    When the tool registry is initialized,
+    Then OpenAI-based tools should be available.
+    """
+    # Unload the autogen module to prevent premature tool registration
+    monkeypatch.delitem(sys.modules, "mcp_the_force.tools.autogen", raising=False)
+
+    # Clear the tool registry to ensure a clean state
+    TOOL_REGISTRY.clear()
+
+    # Set the OPENAI_API_KEY environment variable
+    monkeypatch.setenv("OPENAI_API_KEY", "test_key")
+
+    # Reload the settings to reflect the change
+    from mcp_the_force.config import get_settings
+
+    get_settings.cache_clear()
+
+    # Re-import the autogen module to trigger tool registration
+
+    # List available tools
+    available_tools = list_tools()
+
+    # Assert that OpenAI tools are in the registry
+    assert "chat_with_o3" in available_tools


### PR DESCRIPTION
This commit introduces an integration test to verify that the application correctly handles the loading and unloading of tools based on the presence of API keys in the configuration.

The key changes are:
- A new integration test file, `tests/integration/test_tool_loading.py`, has been added.
- The `mcp_the_force/tools/autogen.py` file has been modified to check if a provider is enabled in the configuration before attempting to load its adapter.

This ensures that the application does not expose tools for providers that are not configured, improving the robustness and stability of the system.