### PR TITLE
feat: upgrade Claude Opus 4 to Claude Opus 4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ All tools share a common set of parameters like `instructions`, `context`, `sess
 - `chat_with_gemini25_flash`: High-speed summarization and analysis (1M context)
 
 ### Anthropic Models
-- `chat_with_claude4_opus`: Deep analysis and formal reasoning with extended thinking (200k context)
+- `chat_with_claude41_opus`: Deep analysis and formal reasoning with extended thinking (200k context)
 - `chat_with_claude4_sonnet`: Fast long-context processing with extended thinking (200k context)
 - `chat_with_claude3_opus`: Exceptional theory of mind and thoughtful discussions (200k context)
 

--- a/mcp_the_force/adapters/anthropic/adapter.py
+++ b/mcp_the_force/adapters/anthropic/adapter.py
@@ -16,7 +16,7 @@ class AnthropicAdapter(LiteLLMBaseAdapter):
 
     param_class = AnthropicToolParams
 
-    def __init__(self, model: str = "claude-opus-4-20250514"):
+    def __init__(self, model: str = "claude-opus-4-1-20250805"):
         """Initialize Anthropic adapter."""
         if model not in ANTHROPIC_MODEL_CAPABILITIES:
             raise ValueError(

--- a/mcp_the_force/adapters/anthropic/blueprints.py
+++ b/mcp_the_force/adapters/anthropic/blueprints.py
@@ -15,6 +15,7 @@ def _get_friendly_name(model_name: str) -> str:
     - 'claude-3-opus' -> 'chat_with_claude3_opus'
     - 'claude-opus-4-0' -> 'chat_with_claude4_opus'
     - 'claude-sonnet-4-0' -> 'chat_with_claude4_sonnet'
+    - 'claude-opus-4-1-20250805' -> 'chat_with_claude41_opus'
     """
     # Remove -0 suffix if present
     if model_name.endswith("-0"):
@@ -27,6 +28,14 @@ def _get_friendly_name(model_name: str) -> str:
         if parts[0] == "claude" and parts[1].isdigit():
             # Pattern: claude-3-opus -> claude3_opus
             result = f"{parts[0]}{parts[1]}_{parts[2]}"
+        elif (
+            parts[0] == "claude"
+            and parts[2] == "4"
+            and parts[3] == "1"
+            and len(parts) >= 5
+        ):
+            # Pattern: claude-opus-4-1-20250805 -> claude41_opus
+            result = f"{parts[0]}{parts[2]}{parts[3]}_{parts[1]}"
         elif parts[0] == "claude" and parts[2] == "4":
             # Pattern: claude-opus-4 -> claude4_opus
             result = f"{parts[0]}{parts[2]}_{parts[1]}"

--- a/mcp_the_force/adapters/anthropic/capabilities.py
+++ b/mcp_the_force/adapters/anthropic/capabilities.py
@@ -23,10 +23,10 @@ class AnthropicBaseCapabilities(AdapterCapabilities):
 
 
 @dataclass
-class Claude4OpusCapabilities(AnthropicBaseCapabilities):
-    """Capabilities for Claude 4 Opus."""
+class Claude41OpusCapabilities(AnthropicBaseCapabilities):
+    """Capabilities for Claude 4.1 Opus."""
 
-    model_name: str = "claude-opus-4-20250514"
+    model_name: str = "claude-opus-4-1-20250805"
     max_context_window: int = 200_000
     max_output_tokens: int = 32_000
     supports_reasoning_effort: bool = True
@@ -61,7 +61,7 @@ class Claude3OpusCapabilities(AnthropicBaseCapabilities):
 
 # Map of model names to their capability instances
 ANTHROPIC_MODEL_CAPABILITIES: Dict[str, AnthropicBaseCapabilities] = {
-    "claude-opus-4-20250514": Claude4OpusCapabilities(),
+    "claude-opus-4-1-20250805": Claude41OpusCapabilities(),
     "claude-sonnet-4-20250514": Claude4SonnetCapabilities(),
     "claude-3-opus-20240229": Claude3OpusCapabilities(),
 }

--- a/mcp_the_force/adapters/anthropic/definitions.py
+++ b/mcp_the_force/adapters/anthropic/definitions.py
@@ -9,7 +9,7 @@ from .capabilities import (
     ANTHROPIC_MODEL_CAPABILITIES,
     AnthropicBaseCapabilities,
     Claude3OpusCapabilities,
-    Claude4OpusCapabilities,
+    Claude41OpusCapabilities,
     Claude4SonnetCapabilities,
 )
 
@@ -20,7 +20,7 @@ __all__ = [
     "ANTHROPIC_MODEL_CAPABILITIES",
     "AnthropicBaseCapabilities",
     "Claude3OpusCapabilities",
-    "Claude4OpusCapabilities",
+    "Claude41OpusCapabilities",
     "Claude4SonnetCapabilities",
     "AnthropicToolParams",
 ]

--- a/tests/unit/test_anthropic_adapter.py
+++ b/tests/unit/test_anthropic_adapter.py
@@ -5,7 +5,7 @@ import pytest
 
 from mcp_the_force.adapters.anthropic.adapter import AnthropicAdapter
 from mcp_the_force.adapters.anthropic.capabilities import (
-    Claude4OpusCapabilities,
+    Claude41OpusCapabilities,
     Claude4SonnetCapabilities,
     Claude3OpusCapabilities,
 )
@@ -18,7 +18,7 @@ class TestAnthropicAdapter:
     def test_supported_models(self):
         """Test that all expected models are supported."""
         models = AnthropicAdapter.get_supported_models()
-        assert "claude-opus-4-20250514" in models
+        assert "claude-opus-4-1-20250805" in models
         assert "claude-sonnet-4-20250514" in models
         assert "claude-3-opus-20240229" in models
         assert len(models) == 3
@@ -27,7 +27,7 @@ class TestAnthropicAdapter:
         """Test model string formatting for LiteLLM."""
         adapter = AnthropicAdapter()
         assert adapter._get_model_prefix() == "anthropic"
-        assert adapter.model_name == "claude-opus-4-20250514"  # Default model
+        assert adapter.model_name == "claude-opus-4-1-20250805"  # Default model
 
     @patch("mcp_the_force.config.get_settings")
     def test_api_key_validation(self, mock_settings):
@@ -35,7 +35,7 @@ class TestAnthropicAdapter:
         # Test with valid API key
         mock_settings.return_value.anthropic.api_key = "sk-ant-test-key"
         adapter = AnthropicAdapter()  # Should not raise
-        assert adapter.model_name == "claude-opus-4-20250514"
+        assert adapter.model_name == "claude-opus-4-1-20250805"
 
         # Test without API key
         mock_settings.return_value.anthropic.api_key = None
@@ -63,10 +63,10 @@ class TestAnthropicAdapter:
         params.thinking_budget = 32768
         assert params.get_thinking_budget() == 32768
 
-    def test_claude4_opus_capabilities(self):
-        """Test Claude 4 Opus capabilities."""
-        caps = Claude4OpusCapabilities()
-        assert caps.model_name == "claude-opus-4-20250514"
+    def test_claude41_opus_capabilities(self):
+        """Test Claude 4.1 Opus capabilities."""
+        caps = Claude41OpusCapabilities()
+        assert caps.model_name == "claude-opus-4-1-20250805"
         assert caps.max_context_window == 200_000
         assert caps.max_output_tokens == 32_000
         assert caps.supports_reasoning_effort is True

--- a/tests/unit/test_anthropic_blueprints.py
+++ b/tests/unit/test_anthropic_blueprints.py
@@ -21,13 +21,13 @@ class TestAnthropicBlueprints:
         blueprints = get_anthropic_blueprints()
         # Check model names
         model_names = [bp.model_name for bp in blueprints]
-        assert "claude-opus-4-20250514" in model_names
+        assert "claude-opus-4-1-20250805" in model_names
         assert "claude-sonnet-4-20250514" in model_names
         assert "claude-3-opus-20240229" in model_names
 
         # Check friendly tool names
         tool_names = [bp.tool_name for bp in blueprints]
-        assert "chat_with_claude4_opus" in tool_names
+        assert "chat_with_claude41_opus" in tool_names
         assert "chat_with_claude4_sonnet" in tool_names
         assert "chat_with_claude3_opus" in tool_names
 
@@ -36,7 +36,7 @@ class TestAnthropicBlueprints:
         blueprints = get_anthropic_blueprints()
         model_names = [bp.model_name for bp in blueprints]
 
-        assert "claude-opus-4-20250514" in model_names
+        assert "claude-opus-4-1-20250805" in model_names
         assert "claude-sonnet-4-20250514" in model_names
         assert "claude-3-opus-20240229" in model_names
 
@@ -61,7 +61,7 @@ class TestAnthropicBlueprints:
 
         # Check specific descriptions
         opus4_bp = next(
-            bp for bp in blueprints if bp.model_name == "claude-opus-4-20250514"
+            bp for bp in blueprints if bp.model_name == "claude-opus-4-1-20250805"
         )
         assert "extended thinking" in opus4_bp.description
         assert "32k output" in opus4_bp.description
@@ -85,7 +85,7 @@ class TestAnthropicBlueprints:
             ANTHROPIC_MODEL_CAPABILITIES,
         )
 
-        opus4_caps = ANTHROPIC_MODEL_CAPABILITIES["claude-opus-4-20250514"]
+        opus4_caps = ANTHROPIC_MODEL_CAPABILITIES["claude-opus-4-1-20250805"]
         assert opus4_caps.supports_reasoning_effort is True
         assert opus4_caps.max_context_window == 200_000
 


### PR DESCRIPTION
## Summary
- Upgraded Claude Opus 4 to the latest Claude Opus 4.1 model
- Updated model ID from `claude-opus-4-20250514` to `claude-opus-4-1-20250805`
- Updated all references and tests to use the new model

## Changes
- Renamed `Claude4OpusCapabilities` to `Claude41OpusCapabilities` 
- Updated tool name from `chat_with_claude4_opus` to `chat_with_claude41_opus`
- Updated blueprint generation logic to handle the 4.1 naming pattern
- Fixed import statements in `definitions.py`
- Updated all tests and documentation

## Test plan
- [x] Unit tests pass for anthropic adapter
- [x] Unit tests pass for anthropic blueprints  
- [x] Integration tested with MCP server
- [x] Verified tool registration as `chat_with_claude41_opus`
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.ai/code)