### PR TITLE
fix: correct structured output format for Anthropic models

### DIFF
--- a/mcp_the_force/adapters/anthropic/adapter.py
+++ b/mcp_the_force/adapters/anthropic/adapter.py
@@ -112,7 +112,11 @@ class AnthropicAdapter(LiteLLMBaseAdapter):
         ):
             request_params["response_format"] = {
                 "type": "json_schema",
-                "json_schema": params.structured_output_schema,
+                "json_schema": {
+                    "name": "response",
+                    "schema": params.structured_output_schema,
+                    "strict": True,
+                },
             }
 
         return request_params


### PR DESCRIPTION
## Summary
Fixed the structured output JSON schema format for Anthropic models to prevent KeyError when using structured output with Claude 4.1.

## Problem
When using structured output with Claude 4.1, LiteLLM was throwing a KeyError: 'schema' because the JSON schema was not wrapped in the expected format.

## Solution
Wrapped the structured output schema in the correct format expected by LiteLLM:
```python
{
    "name": "response",
    "schema": params.structured_output_schema,
    "strict": True
}
```

## Test plan
- [x] Unit tests pass
- [x] All pre-commit hooks pass
- [ ] Manual testing with structured output (requires MCP restart)

## References
- LiteLLM Issue: https://github.com/BerriAI/litellm/issues/7755
- LiteLLM Docs: https://docs.litellm.ai/docs/completion/json_mode

🤖 Generated with [Claude Code](https://claude.ai/code)