### PR TITLE
Fix context loss on API retry due to restrictive file size limits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,6 @@ debug_session*.py
 # UV package manager files
 .venv*/
 venv*/
+
+# Claude hooks (local development)
+claude_hooks/

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,15 @@
+{
+  "mcpServers": {
+    "the-force": {
+      "command": "uv",
+      "args": [
+        "run",
+        "--",
+        "mcp-the-force"
+      ],
+      "env": {
+        "LOGGING__DEVELOPER_MODE__ENABLED": "true"
+      }
+    }
+  }
+}

--- a/.repo_ignore
+++ b/.repo_ignore
@@ -7,3 +7,5 @@ coverage.xml
 uv.lock
 victoria-logs-data/
 .mcp_vector_stores.db
+.venv-py313/
+.buildx-cache/

--- a/mcp_the_force/adapters/anthropic/adapter.py
+++ b/mcp_the_force/adapters/anthropic/adapter.py
@@ -112,7 +112,11 @@ class AnthropicAdapter(LiteLLMBaseAdapter):
         ):
             request_params["response_format"] = {
                 "type": "json_schema",
-                "json_schema": params.structured_output_schema,
+                "json_schema": {
+                    "name": "response",
+                    "schema": params.structured_output_schema,
+                    "strict": True,
+                },
             }
 
         return request_params

--- a/mcp_the_force/config.py
+++ b/mcp_the_force/config.py
@@ -97,6 +97,18 @@ class MCPConfig(BaseModel):
     default_vector_store_provider: str = Field(
         "openai", description="Default provider for vector stores"
     )
+    max_file_size: int = Field(
+        50 * 1024 * 1024,  # 50MB
+        description="Maximum file size to process (bytes). Larger files are skipped.",
+        ge=1024 * 1024,  # Min 1MB
+        le=500 * 1024 * 1024,  # Max 500MB
+    )
+    max_total_size: int = Field(
+        200 * 1024 * 1024,  # 200MB
+        description="Maximum total size of all files to process (bytes)",
+        ge=10 * 1024 * 1024,  # Min 10MB
+        le=1024 * 1024 * 1024,  # Max 1GB
+    )
 
 
 class SessionConfig(BaseModel):

--- a/mcp_the_force/optimization/models.py
+++ b/mcp_the_force/optimization/models.py
@@ -1,7 +1,7 @@
 """Data models for token budget optimization."""
 
-from dataclasses import dataclass
-from typing import List, Optional
+from dataclasses import dataclass, field
+from typing import List, Optional, Tuple
 
 
 @dataclass
@@ -27,6 +27,8 @@ class Plan:
     optimized_prompt: str  # The final optimized XML prompt
     messages: List[dict]  # Complete message list (dev + history + user)
     overflow_paths: Optional[List[str]] = None  # For backward compatibility
+    # Files that should be marked as sent once the call succeeds
+    sent_files_info: List[Tuple[str, int, int]] = field(default_factory=list)
 
     @property
     def inline_paths(self) -> List[str]:

--- a/mcp_the_force/tools/parameter_router.py
+++ b/mcp_the_force/tools/parameter_router.py
@@ -46,6 +46,9 @@ class ParameterRouter:
 
             param_info = metadata.parameters[name]
             route = param_info.route
+            logger.debug(
+                f"[ROUTER] Routing parameter '{name}' with value type {type(value).__name__} to route '{route}'"
+            )
 
             if route == RouteType.PROMPT:
                 if param_info.position is not None:
@@ -91,4 +94,7 @@ class ParameterRouter:
         for _, name, value in prompt_params:
             prompt_dict[name] = value
 
+        logger.info(
+            f"[ROUTER] Final routed params - prompt keys: {list(routed['prompt'].keys() if isinstance(routed['prompt'], dict) else [])}"
+        )
         return routed


### PR DESCRIPTION
## Summary
- Fixed critical bug where files over 500KB were rejected, causing context loss on API retries
- Made file size limits configurable (50MB default, was hardcoded 500KB)
- Added deferred cache updates to prevent marking files as sent before API success

## Problem
When API calls failed and were retried, they would receive no context. This was caused by:
1. Files over 500KB (like 628KB log files) were being rejected by a hardcoded limit
2. This limit was too restrictive for modern LLMs with large context windows (200k-1M tokens)
3. Files were being marked as "sent" in cache before API calls completed

## Solution
1. Removed hardcoded 500KB limit from `_is_text_file()`
2. Made file size limits configurable via settings:
   - `max_file_size`: 50MB default (was 500KB)
   - `max_total_size`: 200MB default
3. Moved size checking to `gather_file_paths()` where it belongs
4. Added deferred cache updates - files are only marked as sent after successful API calls
5. Added comprehensive regression tests to prevent this issue

## Test plan
- [x] Unit tests pass (including new regression tests)
- [x] Integration tests pass
- [x] Verified 628KB file is now loaded correctly
- [x] Tested with actual query that was failing

🤖 Generated with [Claude Code](https://claude.ai/code)